### PR TITLE
[alsa] Fix sound card selection

### DIFF
--- a/rpm/jolla-hw-adaptation-pinephone.spec
+++ b/rpm/jolla-hw-adaptation-pinephone.spec
@@ -16,7 +16,11 @@ Requires: mesa-libglapi
 Requires: wayland-egl
 Requires: qt5-plugin-platform-eglfs
 
-# bluetooth tools
+# Splash screen
+Requires: plymouth-lite
+Requires: plymouth-lite-theme-default
+
+# Bluetooth tools
 Requires: bluez5-tools
 #Requires: bluetooth-rfkill-event-hciattach
 

--- a/sparse/etc/asound.conf
+++ b/sparse/etc/asound.conf
@@ -1,0 +1,25 @@
+#
+# Place your global alsa-lib configuration here...
+#
+
+# A64 sound card as default instead of the EC25 modem sound card
+pcm.!default {
+    type hw
+    card 1
+}
+
+ctl.!default {
+    type hw           
+    card 1
+}
+
+@hooks [
+	{
+		func load
+		files [
+			"/etc/alsa/pulse-default.conf"
+		]
+		errors false
+	}
+]
+

--- a/sparse/usr/bin/droid/unmute-sound-card.sh
+++ b/sparse/usr/bin/droid/unmute-sound-card.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Unmute the A64 sound card at boot
+CARD=1 # A64 sound card
 
-amixer -c 0 set 'AIF1 Slot 0 Digital DAC' unmute
-amixer -c 0 set 'Line Out' unmute
-amixer -c 0 set 'Line Out' 100%
+amixer -c $CARD set 'AIF1 Slot 0 Digital DAC' unmute
+amixer -c $CARD set 'Line Out' unmute
+amixer -c $CARD set 'Line Out' 100%


### PR DESCRIPTION
@neochapay related to the EC25 modem: the EC25 sound card is now card 0, the A64 sound card is now card 1