### PR TITLE
[config] Configure LED base directories for MCE

### DIFF
--- a/sparse/etc/mce/99-pinephone.ini
+++ b/sparse/etc/mce/99-pinephone.ini
@@ -1,0 +1,9 @@
+[LEDConfigHybris]
+
+# Choose Vanilla backend
+BackEnd=vanilla
+
+# Configure base directories for red/green/blue channels
+RedDirectory=/sys/class/leds/pinephone:red:user
+GreenDirectory=/sys/class/leds/pinephone:green:user
+BlueDirectory=/sys/class/leds/pinephone:blue:user


### PR DESCRIPTION
Adds a config file to point MCE to the right directories to control the notification LED on the PinePhone dev phone. 