### PR TITLE
[config] Use drm egl platform

### DIFF
--- a/sparse/var/lib/environment/compositor/droid-hal-device.conf
+++ b/sparse/var/lib/environment/compositor/droid-hal-device.conf
@@ -1,6 +1,6 @@
 # Config for dontbeevil
 #QT_DEBUG_PLUGINS=1
-EGL_PLATFORM=fbdev
+EGL_PLATFORM=drm
 QT_QPA_EGLFS_KMS_CONFIG=/etc/eglfs-config.json
 QT_QPA_EGLFS_INTEGRATION=eglfs_kms
 QT_QPA_PLATFORM=eglfs


### PR DESCRIPTION
fbdev platform now not use in mesa https://git.sailfishos.org/mirror/mesa/blob/19.3/src/egl/main/egldisplay.c#L70