### PR TITLE
Disable connman DNS proxy.

### DIFF
--- a/sparse/var/lib/environment/connman/nodnsproxy.conf
+++ b/sparse/var/lib/environment/connman/nodnsproxy.conf
@@ -1,0 +1,3 @@
+# Disable connman's DNS proxy and instead rely on DNS from DHCP,
+# because it seems to  cause issues with local DNS from DHCP.
+CONNMAN_ARGS="--nodnsproxy"


### PR DESCRIPTION
As reported in #14. I ran into this when testing on the PinePhone. Network would not get DNS. Turning off connman's DNS proxy gave it DNS. The system-level service reads this environment file and `CONNMAN_ARGS` specifically, appending them on to when `connmand` starts.