### PR TITLE
[config] Fix inverted Z axis of accelerometer and gyroscope

### DIFF
--- a/sparse/etc/sensorfw/sensord.conf.d/90-dontbeevil.conf
+++ b/sparse/etc/sensorfw/sensord.conf.d/90-dontbeevil.conf
@@ -2,7 +2,7 @@
 input_match=mpu6050
 intervals = "200=>2000"
 default_interval=500
-transformation_matrix = "0,1,0,-1,0,0,0,0,1"
+transformation_matrix = "0,1,0,-1,0,0,0,0,-1"
 
 [als]
 input_match=stk3310
@@ -13,7 +13,7 @@ default_interval=500
 input_match=mpu6050
 intervals = "200=>2000"
 default_interval=500
-transformation_matrix = "0,1,0,-1,0,0,0,0,1"
+transformation_matrix = "0,1,0,-1,0,0,0,0,-1"
 
 [magnetometer]
 input_match=lis3mdl


### PR DESCRIPTION
This fixes the failure of the CSD tool when testing the accelerometer & gyroscope.
The gyroscope test still fails sometimes, but if you move the phone a bit while doing the test, the test passes. It seems that the sensor isn't so sensitive as the one on other phones.