### PR TITLE
Start mce after the backlight becomes available so that the screen can be powered off

### DIFF
--- a/sparse/etc/systemd/system/mce.service.d/backlight.conf
+++ b/sparse/etc/systemd/system/mce.service.d/backlight.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=sys-devices-platform-backlight-backlight-backlight.device
+Requires=sys-devices-platform-backlight-backlight-backlight.device


### PR DESCRIPTION
powers off correctly