### PR TITLE
Disable PWM breathing

### DIFF
--- a/sparse/etc/mce/99-pinephone.ini
+++ b/sparse/etc/mce/99-pinephone.ini
@@ -7,3 +7,7 @@ BackEnd=vanilla
 RedDirectory=/sys/class/leds/pinephone:red:user
 GreenDirectory=/sys/class/leds/pinephone:green:user
 BlueDirectory=/sys/class/leds/pinephone:blue:user
+
+# No PWM breathing
+QuirkBreathing=true
+QuirkBreathType=2


### PR DESCRIPTION
The notification LED is connected to GPIOs which doesn't support PWM.