### PR TITLE
Make lipstick wait until ofono is ready

### DIFF
--- a/sparse/etc/systemd/system/ofono.service.d/ofono.conf
+++ b/sparse/etc/systemd/system/ofono.service.d/ofono.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPost=/usr/bin/droid/ofono-delay.sh
+TimeoutStartSec=60

--- a/sparse/etc/systemd/user/lipstick.service.d/ofono-wait.conf
+++ b/sparse/etc/systemd/user/lipstick.service.d/ofono-wait.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/droid/lipstick-ofono-wait.sh

--- a/sparse/usr/bin/droid/lipstick-ofono-wait.sh
+++ b/sparse/usr/bin/droid/lipstick-ofono-wait.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+while [ ! -f /run/ofono-ready ] ;
+do
+        echo "Waiting for ofono..."
+        sleep 2
+done
+echo "Ofono ready!"

--- a/sparse/usr/bin/droid/ofono-delay.sh
+++ b/sparse/usr/bin/droid/ofono-delay.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+#Delay until sure the imei has been read
+/bin/sleep 20
+
+#Signal to start lipstick
+touch /run/ofono-ready


### PR DESCRIPTION
This is a bit hacky but read on.
Currently, ofono assumes the sim slot / imei is known immediately.  With
the pinephone, ofono and gobi plugin, the imei is signalled after
startup.  If lipstick is started before the imei/slots are known, then
it assumes no mobile network, unless it is restarted.

This adds 2 service changes.
1. Make ofono wait 30 seconds, and then write a file to indicate it has
   finished startup
2. Make lipstick wait until this file has been created before starting.

It is done this way becuase ofono is a system service, and lipstick is a
user-session service, so making them depend on eachother wasnt working.